### PR TITLE
Fix for issue #63

### DIFF
--- a/Composite.Community.Blog/Composite.Community.Blog.Package/Package/App_Data/Razor/Composite/Community/Blog/BlogRenderer.cshtml
+++ b/Composite.Community.Blog/Composite.Community.Blog.Package/Package/App_Data/Razor/Composite/Community/Blog/BlogRenderer.cshtml
@@ -118,7 +118,7 @@
                     (function () {
                         var s = document.createElement('script'); s.async = true;
                         s.type = 'text/javascript';
-                        s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+                        s.src = '//' + disqus_shortname + '.disqus.com/count.js';
                         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
                     }());
                 </script>

--- a/Composite.Community.Blog/Composite.Community.Blog.Package/Package/App_Data/Razor/Composite/Community/Blog/Comments.cshtml
+++ b/Composite.Community.Blog/Composite.Community.Blog.Package/Package/App_Data/Razor/Composite/Community/Blog/Comments.cshtml
@@ -31,7 +31,7 @@
                 var dsq = document.createElement('script');
                 dsq.type = 'text/javascript';
                 dsq.async = true;
-                dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>


### PR DESCRIPTION
Fix for #63. Converts http:// to // in JavaScript code within BlogRenderer.cshtml and Comments.cshtml Razor files, so that browsers blocking mixed-mode content can display Disqus comments and comment counts.
  